### PR TITLE
Add 2 new ORDER BY syntax mappings

### DIFF
--- a/helper/_resources/config/redshift/function_mappings.json
+++ b/helper/_resources/config/redshift/function_mappings.json
@@ -11,7 +11,7 @@
 "getdate": {"source_name": "getdate", "macro_name": "redshift_getdate"},
 "strtol": {"source_name": "strtol", "macro_name": "strtol"},
 "isnull": {"source_name": "isnull", "macro_name": "isnull"},
-"sysdate": {"source_name": "sysdate", "macro_name": "sysdate"},
+"sysdate": {"source_name": "sysdate", "macro_name": "redshift_sysdate"},
 "datediff": {"source_name": "datediff", "macro_name": "datediff"},
 "date_trunc": {"source_name": "date_trunc", "macro_name": "date_trunc"},
 "date_part": {"source_name": "date_part", "macro_name": "date_part"}

--- a/helper/_resources/config/redshift/syntax_mappings.json
+++ b/helper/_resources/config/redshift/syntax_mappings.json
@@ -6,6 +6,10 @@
                         },
 "isnull_to_coalesce" : {"source_pattern": "isnull",
                         "target_pattern": "coalesce"
-                       }
+                       },
+"order_by_desc_nulls_first_to_last": {"source_pattern": "(ORDER BY)([\\w\\s,]+\\b)(DESC)(?=\\s*$|\\s*\\n*)",
+                                      "target_pattern": "\\1 \\2 \\3 NULLS FIRST"},
+"order_by_asc_nulls_last_to_first_w_keyword": {"source_pattern": "(ORDER BY)([\\w\\s,]+\\b)(ASC)(?=\\s*$|\\s*\\n*)",
+                                      "target_pattern": "\\1 \\2 \\3 NULLS LAST"}
 }
         

--- a/macros/redshift/sysdate.sql
+++ b/macros/redshift/sysdate.sql
@@ -1,3 +1,3 @@
-{% macro sysdate() %}
+{% macro redshift_sysdate() %}
    date_format(current_timestamp(), 'yyyy-MM-dd HH:mm:ss')
 {% endmacro %}

--- a/models/redshift/customerrs.sql
+++ b/models/redshift/customerrs.sql
@@ -36,3 +36,4 @@ select
         ) as test_syntax_change
 from
     redshift_sample_data.tpch_rs1.customer
+ORDER BY colC,colB DESC

--- a/models/redshift/customerrs.sql
+++ b/models/redshift/customerrs.sql
@@ -23,15 +23,13 @@ select
     ISNULL(test, test_is_null) AS null_test_col_caps,
     isnull(test, 'test_is_null') AS null_test_col,
     first_value(
-            case
-                when cte_contract_pricings.contract_years = 3
-                     then cte_contract_pricings.id
+            case when colA = 2 then id2
             end ignore nulls
         ) over (
             partition by
-                cte_contract_pricings.upstart_id
+                customer_id
             order by
-                cte_contract_pricings.created_at, cte_contract_pricings.id
+                created_at
             rows between unbounded preceding and unbounded following
         ) as test_syntax_change
 from

--- a/models/redshift_to_databricks/customerrs.sql
+++ b/models/redshift_to_databricks/customerrs.sql
@@ -24,14 +24,14 @@ select
     coalesce(test, 'test_is_null') AS null_test_col,
     first_value(
             case
-                when cte_contract_pricings.contract_years = 3
-                     then cte_contract_pricings.id
+                when colA = 2
+                     then id2
             end ) ignore nulls
           over (
             partition by
-                cte_contract_pricings.upstart_id
+                customer_id
             order by
-                cte_contract_pricings.created_at, cte_contract_pricings.id
+                created_at
             rows between unbounded preceding and unbounded following
         ) as test_syntax_change
 from

--- a/models/redshift_to_databricks/customerrs.sql
+++ b/models/redshift_to_databricks/customerrs.sql
@@ -1,0 +1,39 @@
+
+{{
+    config(
+        materialized = 'table'
+    )
+}}
+
+select 
+    {{lakehouse_utils.convert("string","c_custkey")}}  as stringkey,
+    c_name,
+    c_address,
+    c_nationkey,
+    c_phone, 
+    {{lakehouse_utils.dlog10("c_acctbal")}}  as actbalbaseten,
+    {{lakehouse_utils.dlog10("c_acctbal")}}  as actbalbaseten,
+    c_mktsegment,
+    c_comment,
+    {{lakehouse_utils.redshift_getdate()}}  as hoy,
+    {{lakehouse_utils.redshift_getdate()}}  AS get_date_caps_test,
+    {{lakehouse_utils.sysdate()}}  AS sys_date_col_test,
+    {{lakehouse_utils.sysdate()}}  AS sys_date_caps_col_test,
+    coalesce(test, test_is_null) AS null_test_col_caps,
+    coalesce(test, test_is_null) AS null_test_col_caps,
+    coalesce(test, 'test_is_null') AS null_test_col,
+    first_value(
+            case
+                when cte_contract_pricings.contract_years = 3
+                     then cte_contract_pricings.id
+            end ) ignore nulls
+          over (
+            partition by
+                cte_contract_pricings.upstart_id
+            order by
+                cte_contract_pricings.created_at, cte_contract_pricings.id
+            rows between unbounded preceding and unbounded following
+        ) as test_syntax_change
+from
+    redshift_sample_data.tpch_rs1.customer
+ORDER BY  colC,colB  DESC NULLS FIRST


### PR DESCRIPTION
Added 2 new ORDER BY syntax mappings to handle default NULL ordering.

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have verified that existing unit tests pass (may need to run dbt seed first)
- [ ] I have added a unit test for each new macro I created and I have verifed that these new unit tests pass. 
